### PR TITLE
Create initial OpenAPI specification

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -224,6 +224,32 @@ paths:
           $ref: '#/components/responses/NotFound'
         default:
           description: Unexpected error
+  /runs/{runId}/replay:
+    get:
+      summary: Return a replay for a specific run
+      tags:
+        - runs
+      parameters:
+        - in: path
+          name: runId
+          schema:
+            type: integer
+          required: true
+          description: Run ID of the run to fetch
+      responses:
+        '200':
+          description: A binary file containing the runs replay
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+        '400':
+          $ref: '#/components/responses/Invalid'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        default:
+          description: Unexpected error
   /servers:
     get:
       summary: Return an array of all connected servers

--- a/openapi.yml
+++ b/openapi.yml
@@ -46,31 +46,6 @@ paths:
           description: Unexpected error
   # /maps/{map}/zones:
   # to be fleshed out upon zone discussion
-  /maps/{map}/runs:
-    get:
-      summary: Return a list of runs hit on a specified map
-      tags:
-        - maps
-      parameters:
-        - in: path
-          name: map
-          schema:
-            type: string
-          required: true
-          description: Name of the map
-      responses:
-        '200':
-          description: An array of Run objects
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/RunArray'
-        '400':
-          $ref: '#/components/responses/Invalid'
-        '404':
-          $ref: '#/components/responses/NotFound'
-        default:
-          description: Unexpected error
   /players/{player}:
     get:
       summary: Return detailed information about a player
@@ -96,36 +71,77 @@ paths:
           $ref: '#/components/responses/NotFound'
         default:
           description: Unexpected error
-  /players/{player}/runs:
+  /runs:
     get:
-      summary: Return a list of all runs hit by a player
+      summary: Return a list of runs matching the given query
       tags:
-        - players
+        - runs
       parameters:
-        - in: path
+        - in: query
+          name: server
+          schema:
+            type: integer
+          description: ID of the server to filter
+        - in: query
           name: player
           schema:
             type: integer
-          required: true
-          description: SteamID64 of the player to fetch
-      responses:
-        '200':
-          description: An array of Run objects
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/RunArray'
-        '400':
-          $ref: '#/components/responses/Invalid'
-        '404':
-          $ref: '#/components/responses/NotFound'
-        default:
-          description: Unexpected error
-  /runs:
-    get:
-      summary: Return a list of all runs
-      tags:
-        - runs
+          description: SteamID64 of the player to filter
+        - in: query
+          name: map
+          schema:
+            type: string
+          description: Name of the map to filter
+        - in: query
+          name: track
+          schema:
+            type: integer
+            default: 0
+          description: Track of the run to filter (Default - 0/Main)
+        - in: query
+          name: style
+          schema:
+            type: integer
+            default: 0
+          description: Style of the run to filter (Default - 0/Auto)
+        - in: query
+          name: sort
+          schema:
+            type: string
+            enum:
+              - id
+              - time
+              - date
+              - sync
+              - strafes
+              - jumps
+              - player_name
+              - map_name
+              - style
+              - server
+              - points
+          description: Column to sort on
+        - in: query
+          name: order
+          schema:
+            type: string
+            enum:
+              - asc
+              - desc
+          description: >
+            Sort order (by Run ID):
+             * `asc` - Ascending, from low to high
+             * `desc` - Descending, from high to low
+        - in: query
+          name: offset
+          schema:
+            type: integer
+          description: The number of items to offset the result by
+        - in: query
+          name: limit
+          schema:
+            type: integer
+          description: The number of items to return
       responses:
         '200':
           description: An array of Run objects

--- a/openapi.yml
+++ b/openapi.yml
@@ -301,7 +301,9 @@ components:
           type: boolean
           description: Is the player currently banned?
         country:
-          type: ['null', string]
+          type:
+            - 'null'
+            - string
           description: The country specified by the player
         steamid:
           type: integer
@@ -366,10 +368,14 @@ components:
           format: ipv4
           description: Server IP address
         discord_link:
-          type: ['null', string]
+          type:
+            - 'null'
+            - string
           description: A link to the server's discord (if it exists)
         owner_steamid:
-          type: ['null', integer]
+          type:
+            - 'null'
+            - integer
           description: The SteamID64 of the server's owner (if it exists)
         country_name:
           type: string

--- a/openapi.yml
+++ b/openapi.yml
@@ -362,3 +362,12 @@ components:
       type: array
       items:
         $ref: '#/components/schemas/Server'
+tags:
+  - name: maps
+    description: All routes relating to maps
+  - name: players
+    description: All routes relating to players
+  - name: runs
+    description: All routes relating to runs
+  - name: servers
+    description: All routes relating to servers

--- a/openapi.yml
+++ b/openapi.yml
@@ -1,4 +1,4 @@
-openapi: '3.0.2'
+openapi: '3.1.0'
 info:
   title: SourceJump API
   version: 1.0.0
@@ -144,7 +144,7 @@ paths:
       tags:
         - runs
       security: 
-        - apiKey: []
+        - ApiKeyAuth: []
       requestBody:
         required: true
         content:
@@ -203,6 +203,7 @@ paths:
           $ref: '#/components/responses/NotFound'
         default:
           description: Unexpected error
+
 # We can store common response objects and types here
 components:
   # Security schemes for protected endpoints (run submission)
@@ -231,6 +232,7 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/Error'
+
   schemas:
     # Generic error response body
     Error:
@@ -283,9 +285,8 @@ components:
           type: boolean
           description: Is the player currently banned?
         country:
-          type: string
+          type: ['null', string]
           description: The country specified by the player
-          nullable: true
         steamid:
           type: integer
           description: SteamID64 of the player
@@ -349,13 +350,11 @@ components:
           format: ipv4
           description: Server IP address
         discord_link:
-          type: string
+          type: ['null', string]
           description: A link to the server's discord (if it exists)
-          nullable: true
         owner_steamid:
-          type: integer
+          type: ['null', integer]
           description: The SteamID64 of the server's owner (if it exists)
-          nullable: true
         country_name:
           type: string
           description: The country the server is hosted in

--- a/openapi.yml
+++ b/openapi.yml
@@ -53,8 +53,31 @@ paths:
           $ref: '#/components/responses/NotFound'
         default:
           description: Unexpected error
-  # /maps/{map}/zones:
-  # to be fleshed out upon zone discussion
+  /maps/{map}/zones:
+    get:
+      summary: Return zone data for the specified map
+      tags:
+        - maps
+      parameters:
+        - in: path
+          name: map
+          schema:
+            type: string
+          required: true
+          description: Name of the map
+      responses:
+        '200':
+          description: An array of Zone objects
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ZoneArray'
+        '400':
+          $ref: '#/components/responses/Invalid'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        default:
+          description: Unexpected error
   /players:
     get:
       summary: Return a list of all players
@@ -393,6 +416,37 @@ components:
       type: array
       items:
         $ref: '#/components/schemas/Server'
+    Zone:
+      type: object
+      properties:
+        id:
+          type: integer
+          description: Numerical zone ID
+        track:
+          type: integer
+          description: Numerical map track
+        type:
+          $ref: '#/components/schemas/ZoneType'
+          description: The zone's type
+        index:
+          type: integer
+          description: The zone's index
+        pointA:
+          type: array
+          items:
+            type: number
+            format: double
+          description: The zone's first point
+        pointB:
+          type: array
+          items:
+            type: number
+            format: double
+          description: The zone's second point
+    ZoneArray:
+      type: array
+      items:
+        $ref: '#/components/schemas/Zone'
     # Reusable enums of model fields
     MapFields:
       type: string
@@ -434,6 +488,14 @@ components:
         - discordLink
         - ownerSteamid
         - countryName
+    ZoneType:
+      type: string
+      enum:
+        - start
+        - end
+        - stop
+        - stage
+        - freestyle
   parameters:
     OffsetParam:
       in: query

--- a/openapi.yml
+++ b/openapi.yml
@@ -8,7 +8,7 @@ paths:
   /maps:
     get:
       summary: Return a list of all maps
-      tags: 
+      tags:
         - maps
       responses:
         '200':
@@ -22,7 +22,7 @@ paths:
   /maps/{map}:
     get:
       summary: Return detailed information about a specified map
-      tags: 
+      tags:
         - maps
       parameters:
         - in: path
@@ -49,7 +49,7 @@ paths:
   /maps/{map}/runs:
     get:
       summary: Return a list of runs hit on a specified map
-      tags: 
+      tags:
         - maps
       parameters:
         - in: path
@@ -143,7 +143,7 @@ paths:
       summary: Creates a run entry
       tags:
         - runs
-      security: 
+      security:
         - ApiKeyAuth: []
       requestBody:
         required: true
@@ -160,7 +160,7 @@ paths:
           $ref: '#/components/responses/Unauthorized'
         default:
           description: Unexpected error
-  /runs/{runId}: 
+  /runs/{runId}:
     get:
       summary: Return detailed information about a specific run
       tags:
@@ -274,7 +274,7 @@ components:
       properties:
         id:
           type: integer
-          description: Numerical player ID 
+          description: Numerical player ID
         name:
           type: string
           description: Player name

--- a/openapi.yml
+++ b/openapi.yml
@@ -10,6 +10,15 @@ paths:
       summary: Return a list of all maps
       tags:
         - maps
+      parameters:
+        - in: query
+          name: sort
+          schema:
+            $ref: '#/components/schemas/MapFields'
+          description: Column to sort on
+        - $ref: '#/components/parameters/orderParam'
+        - $ref: '#/components/parameters/offsetParam'
+        - $ref: '#/components/parameters/limitParam'
       responses:
         '200':
           description: An array of Map objects
@@ -176,6 +185,15 @@ paths:
       summary: Return an array of all connected servers
       tags:
         - servers
+      parameters:
+        - in: query
+          name: sort
+          schema:
+            $ref: '#/components/schemas/ServerFields'
+          description: Column to sort on
+        - $ref: '#/components/parameters/orderParam'
+        - $ref: '#/components/parameters/offsetParam'
+        - $ref: '#/components/parameters/limitParam'
       responses:
         '200':
           description: An array of Server objects
@@ -354,7 +372,24 @@ components:
       type: array
       items:
         $ref: '#/components/schemas/Server'
-    # Reusable enum of all run model fields
+    # Reusable enums of model fields
+    MapFields:
+      type: string
+      enum:
+        - id
+        - name
+        - tier
+        - created_at
+        - author
+    PlayerFields:
+      type: string
+      enum:
+        - id
+        - name
+        - points
+        - banned
+        - country
+        - steamid
     RunFields:
       type: string
       enum:
@@ -369,6 +404,15 @@ components:
         - style
         - server
         - points
+    ServerFields:
+      type: string
+      enum:
+        - id
+        - name
+        - address
+        - discord_link
+        - owner_steamid
+        - country_name
   parameters:
     offsetParam:
       in: query

--- a/openapi.yml
+++ b/openapi.yml
@@ -40,8 +40,6 @@ paths:
                 $ref: '#/components/schemas/Map'
         '400':
           $ref: '#/components/responses/Invalid'
-        '401':
-          $ref: '#/components/responses/Unauthorized'
         '404':
           $ref: '#/components/responses/NotFound'
         default:
@@ -69,8 +67,6 @@ paths:
                 $ref: '#/components/schemas/RunArray'
         '400':
           $ref: '#/components/responses/Invalid'
-        '401':
-          $ref: '#/components/responses/Unauthorized'
         '404':
           $ref: '#/components/responses/NotFound'
         default:
@@ -96,8 +92,6 @@ paths:
                 $ref: '#/components/schemas/Player'
         '400':
           $ref: '#/components/responses/Invalid'
-        '401':
-          $ref: '#/components/responses/Unauthorized'
         '404':
           $ref: '#/components/responses/NotFound'
         default:
@@ -123,8 +117,6 @@ paths:
                 $ref: '#/components/schemas/RunArray'
         '400':
           $ref: '#/components/responses/Invalid'
-        '401':
-          $ref: '#/components/responses/Unauthorized'
         '404':
           $ref: '#/components/responses/NotFound'
         default:
@@ -143,8 +135,6 @@ paths:
                 $ref: '#/components/schemas/RunArray'
         '400':
           $ref: '#/components/responses/Invalid'
-        '401':
-          $ref: '#/components/responses/Unauthorized'
         '404':
           $ref: '#/components/responses/NotFound'
         default:
@@ -191,8 +181,6 @@ paths:
                 $ref: '#/components/schemas/Run'
         '400':
           $ref: '#/components/responses/Invalid'
-        '401':
-          $ref: '#/components/responses/Unauthorized'
         '404':
           $ref: '#/components/responses/NotFound'
         default:
@@ -211,13 +199,10 @@ paths:
                 $ref: '#/components/schemas/ServerArray'
         '400':
           $ref: '#/components/responses/Invalid'
-        '401':
-          $ref: '#/components/responses/Unauthorized'
         '404':
           $ref: '#/components/responses/NotFound'
         default:
           description: Unexpected error
-
 # We can store common response objects and types here
 components:
   # Security schemes for protected endpoints (run submission)
@@ -246,7 +231,6 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/Error'
-
   schemas:
     # Generic error response body
     Error:

--- a/openapi.yml
+++ b/openapi.yml
@@ -1,0 +1,381 @@
+openapi: '3.0.2'
+info:
+  title: SourceJump API
+  version: 1.0.0
+servers:
+  - url: https://sourcejump.net/api/v1
+paths:
+  /maps:
+    get:
+      summary: Return a list of all maps
+      tags: 
+        - maps
+      responses:
+        '200':
+          description: An array of Map objects
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MapArray'
+        default:
+          description: Unexpected error
+  /maps/{map}:
+    get:
+      summary: Return detailed information about a specified map
+      tags: 
+        - maps
+      parameters:
+        - in: path
+          name: map
+          schema:
+            type: string
+          required: true
+          description: Name of the map
+      responses:
+        '200':
+          description: A Map opject
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Map'
+        '400':
+          $ref: '#/components/responses/Invalid'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        default:
+          description: Unexpected error
+  # /maps/{map}/zones:
+  # to be fleshed out upon zone discussion
+  /maps/{map}/runs:
+    get:
+      summary: Return a list of runs hit on a specified map
+      tags: 
+        - maps
+      parameters:
+        - in: path
+          name: map
+          schema:
+            type: string
+          required: true
+          description: Name of the map
+      responses:
+        '200':
+          description: An array of Run objects
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RunArray'
+        '400':
+          $ref: '#/components/responses/Invalid'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        default:
+          description: Unexpected error
+  /players/{player}:
+    get:
+      summary: Return detailed information about a player
+      tags:
+        - players
+      parameters:
+        - in: path
+          name: player
+          schema:
+            type: integer
+          required: true
+          description: SteamID64 of the player to fetch
+      responses:
+        '200':
+          description: A Player object
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Player'
+        '400':
+          $ref: '#/components/responses/Invalid'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        default:
+          description: Unexpected error
+  /players/{player}/runs:
+    get:
+      summary: Return a list of all runs hit by a player
+      tags:
+        - players
+      parameters:
+        - in: path
+          name: player
+          schema:
+            type: integer
+          required: true
+          description: SteamID64 of the player to fetch
+      responses:
+        '200':
+          description: An array of Run objects
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RunArray'
+        '400':
+          $ref: '#/components/responses/Invalid'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        default:
+          description: Unexpected error
+  /runs:
+    get:
+      summary: Return a list of all runs
+      tags:
+        - runs
+      responses:
+        '200':
+          description: An array of Run objects
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RunArray'
+        '400':
+          $ref: '#/components/responses/Invalid'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        default:
+          description: Unexpected error
+    post:
+      summary: Creates a run entry
+      tags:
+        - runs
+      security: 
+        - apiKey: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Run'
+      responses:
+        '201':
+          description: created
+        '400':
+          $ref: '#/components/responses/Invalid'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        default:
+          description: Unexpected error
+  /runs/{runId}: 
+    get:
+      summary: Return detailed information about a specific run
+      tags:
+        - runs
+      parameters:
+        - in: path
+          name: runId
+          schema:
+            type: integer
+          required: true
+          description: Run ID of the run to fetch
+      responses:
+        '200':
+          description: A Run object
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Run'
+        '400':
+          $ref: '#/components/responses/Invalid'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        default:
+          description: Unexpected error
+  /servers:
+    get:
+      summary: Return an array of all connected servers
+      tags:
+        - servers
+      responses:
+        '200':
+          description: An array of Server objects
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ServerArray'
+        '400':
+          $ref: '#/components/responses/Invalid'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        default:
+          description: Unexpected error
+
+# We can store common response objects and types here
+components:
+  # Security schemes for protected endpoints (run submission)
+  securitySchemes:
+    ApiKeyAuth:
+      type: apiKey
+      in: header
+      name: X-API-Key
+  # Common response objects
+  responses:
+    NotFound:
+      description: The specified resource was not found
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+    Invalid:
+      description: The request was invalid
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+    Unauthorized:
+      description: Unauthorized request
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+
+  schemas:
+    # Generic error response body
+    Error:
+      type: object
+      properties:
+        code:
+          type: string
+        message:
+          type: string
+      required:
+        - code
+        - string
+    # General response objects
+    Map:
+      type: object
+      properties:
+        id:
+          type: integer
+          description: Numerical map ID
+        name:
+          type: string
+          description: Name of the map
+        tier:
+          type: integer
+          description: Difficulty tier of the map
+        created_at:
+          type: string
+          format: date
+          description: When the map was created
+        author:
+          type: string
+          description: Author of the map
+    MapArray:
+      type: array
+      items:
+        $ref: '#/components/schemas/Map'
+    Player:
+      type: object
+      properties:
+        id:
+          type: integer
+          description: Numerical player ID 
+        name:
+          type: string
+          description: Player name
+        points:
+          type: integer
+          description: Amount of points the player has
+        banned:
+          type: boolean
+          description: Is the player currently banned?
+        country:
+          type: string
+          description: The country specified by the player
+          nullable: true
+        steamid:
+          type: integer
+          description: SteamID64 of the player
+    PlayerArray:
+      type: array
+      items:
+        $ref: '#/components/schemas/Player'
+    Run:
+      type: object
+      properties:
+        id:
+          type: integer
+          description: Numerical run ID
+        time:
+          type: integer
+          description: Length of the run in ticks
+        date:
+          type: string
+          format: date-time
+          description: When the run was hit
+        sync:
+          type: number
+          format: double
+          description: The runs sync
+        strafes:
+          type: integer
+          description: The amount of strafes in the run
+        jumps:
+          type: integer
+          description: The amount of jumps in the run
+        player_name:
+          type: string
+          description: The name of the player that hit the run
+        map_name:
+          type: string
+          description: The name of the map the run was on
+        style:
+          type: string
+          description: The style the run was played on
+        server:
+          type: string
+          description: The name of the server the run was hit on
+        points:
+          type: integer
+          description: The amount of points awarded for the run
+    RunArray:
+      type: array
+      items:
+        $ref: '#/components/schemas/Run'
+    Server:
+      type: object
+      properties:
+        id:
+          type: integer
+          description: Numerical server ID
+        name:
+          type: string
+          description: Server name
+        address:
+          type: string
+          format: ipv4
+          description: Server IP address
+        discord_link:
+          type: string
+          description: A link to the server's discord (if it exists)
+          nullable: true
+        owner_steamid:
+          type: integer
+          description: The SteamID64 of the server's owner (if it exists)
+          nullable: true
+        country_name:
+          type: string
+          description: The country the server is hosted in
+    ServerArray:
+      type: array
+      items:
+        $ref: '#/components/schemas/Server'

--- a/openapi.yml
+++ b/openapi.yml
@@ -544,6 +544,8 @@ components:
       name: offset
       schema:
         type: integer
+        minimum: 0
+        default: 0
       description: The number of items to offset the result by
     OrderParam:
       in: query
@@ -562,6 +564,9 @@ components:
       name: limit
       schema:
         type: integer
+        minimum: 1
+        maximum: 100
+        default: 50
       description: The number of items to return
 tags:
   - name: maps

--- a/openapi.yml
+++ b/openapi.yml
@@ -303,16 +303,41 @@ components:
         name:
           type: string
           description: Name of the map
+        author:
+          type: string
+          description: Author of the map
         tier:
           type: integer
           description: Difficulty tier of the map
+        type:
+          $ref: '#/components/schemas/MapType'
+          description: The type of the map
+        stages:
+          type: integer
+          description: How many stages the map has
+        bonuses:
+          type: integer
+          description: How many bonuses the map has
+        fileChecksum:
+          type: integer
+          description: The checksum of the map file
+        fileSize:
+          type: integer
+          description: The size of the map (in bytes)
+        downloadUrl:
+          type: string
+          description: Where to download the map from
+        thumbnailUrl:
+          type: string
+          description: Where the thumbnail image of the map is hosted
         createdAt:
           type: string
           format: date
           description: When the map was created
-        author:
+        updatedAt:
           type: string
-          description: Author of the map
+          format: date
+          description: When the map was last updated
     MapArray:
       type: array
       items:
@@ -350,35 +375,38 @@ components:
         id:
           type: integer
           description: Numerical run ID
-        time:
-          type: integer
-          description: Length of the run in ticks
-        date:
+        datetime:
           type: string
           format: date-time
           description: When the run was hit
-        sync:
-          type: number
-          format: double
-          description: The runs sync
-        strafes:
+        server:
+          $ref: '#/components/schemas/Server'
+          description: The server the run was hit on
+        player:
+          $ref: '#/components/schemas/Player'
+          description: The player that hit the run
+        map:
+          $ref: '#/components/schemas/Map'
+          description: The map the run was hit on
+        track:
           type: integer
-          description: The amount of strafes in the run
+          description: The track number the run was hit on
+        style:
+          type: integer
+          description: The style number the run was hit on
+        ticks:
+          type: integer
+          description: Length of the run in ticks
         jumps:
           type: integer
           description: The amount of jumps in the run
-        playerName:
-          type: string
-          description: The name of the player that hit the run
-        mapName:
-          type: string
-          description: The name of the map the run was on
-        style:
-          type: string
-          description: The style the run was played on
-        server:
-          type: string
-          description: The name of the server the run was hit on
+        strafes:
+          type: integer
+          description: The amount of strafes in the run
+        sync:
+          type: number
+          format: float
+          description: The runs sync
         points:
           type: integer
           description: The amount of points awarded for the run
@@ -453,9 +481,17 @@ components:
       enum:
         - id
         - name
-        - tier
-        - createdAt
         - author
+        - tier
+        - type
+        - stages
+        - bonuses
+        - fileChecksum
+        - fileSize
+        - downloadUrl
+        - thumbnailUrl
+        - createdAt
+        - updatedAt
     PlayerFields:
       type: string
       enum:
@@ -469,15 +505,16 @@ components:
       type: string
       enum:
         - id
-        - time
-        - date
-        - sync
-        - strafes
-        - jumps
-        - playerName
-        - mapName
-        - style
+        - datetime
         - server
+        - player
+        - map
+        - track
+        - style
+        - ticks
+        - jumps
+        - strafes
+        - sync
         - points
     ServerFields:
       type: string
@@ -488,6 +525,11 @@ components:
         - discordLink
         - ownerSteamid
         - countryName
+    MapType:
+      type: string
+      enum:
+        - linear
+        - staged
     ZoneType:
       type: string
       enum:

--- a/openapi.yml
+++ b/openapi.yml
@@ -107,7 +107,7 @@ paths:
         - in: query
           name: sort
           schema:
-            $ref: '#/components/schemas/MapFields'
+            $ref: '#/components/schemas/RunFields'
           description: Column to sort on
         - $ref: '#/components/parameters/orderParam'
         - $ref: '#/components/parameters/offsetParam'
@@ -354,8 +354,8 @@ components:
       type: array
       items:
         $ref: '#/components/schemas/Server'
-    # Reusable enum of all map model fields
-    MapFields:
+    # Reusable enum of all run model fields
+    RunFields:
       type: string
       enum:
         - id

--- a/openapi.yml
+++ b/openapi.yml
@@ -107,41 +107,11 @@ paths:
         - in: query
           name: sort
           schema:
-            type: string
-            enum:
-              - id
-              - time
-              - date
-              - sync
-              - strafes
-              - jumps
-              - player_name
-              - map_name
-              - style
-              - server
-              - points
+            $ref: '#/components/schemas/MapFields'
           description: Column to sort on
-        - in: query
-          name: order
-          schema:
-            type: string
-            enum:
-              - asc
-              - desc
-          description: >
-            Sort order (by Run ID):
-             * `asc` - Ascending, from low to high
-             * `desc` - Descending, from high to low
-        - in: query
-          name: offset
-          schema:
-            type: integer
-          description: The number of items to offset the result by
-        - in: query
-          name: limit
-          schema:
-            type: integer
-          description: The number of items to return
+        - $ref: '#/components/parameters/orderParam'
+        - $ref: '#/components/parameters/offsetParam'
+        - $ref: '#/components/parameters/limitParam'
       responses:
         '200':
           description: An array of Run objects
@@ -384,6 +354,46 @@ components:
       type: array
       items:
         $ref: '#/components/schemas/Server'
+    # Reusable enum of all map model fields
+    MapFields:
+      type: string
+      enum:
+        - id
+        - time
+        - date
+        - sync
+        - strafes
+        - jumps
+        - player_name
+        - map_name
+        - style
+        - server
+        - points
+  parameters:
+    offsetParam:
+      in: query
+      name: offset
+      schema:
+        type: integer
+      description: The number of items to offset the result by
+    orderParam:
+      in: query
+      name: order
+      schema:
+        type: string
+        enum:
+          - asc
+          - desc
+      description: >
+        Sort order (by Run ID):
+          * `asc` - Ascending, from low to high
+          * `desc` - Descending, from high to low
+    limitParam:
+      in: query
+      name: limit
+      schema:
+        type: integer
+      description: The number of items to return
 tags:
   - name: maps
     description: All routes relating to maps

--- a/openapi.yml
+++ b/openapi.yml
@@ -16,9 +16,9 @@ paths:
           schema:
             $ref: '#/components/schemas/MapFields'
           description: Column to sort on
-        - $ref: '#/components/parameters/orderParam'
-        - $ref: '#/components/parameters/offsetParam'
-        - $ref: '#/components/parameters/limitParam'
+        - $ref: '#/components/parameters/OrderParam'
+        - $ref: '#/components/parameters/OffsetParam'
+        - $ref: '#/components/parameters/LimitParam'
       responses:
         '200':
           description: An array of Map objects
@@ -66,9 +66,9 @@ paths:
           schema:
             $ref: '#/components/schemas/PlayerFields'
           description: Column to sort on
-        - $ref: '#/components/parameters/orderParam'
-        - $ref: '#/components/parameters/offsetParam'
-        - $ref: '#/components/parameters/limitParam'
+        - $ref: '#/components/parameters/OrderParam'
+        - $ref: '#/components/parameters/OffsetParam'
+        - $ref: '#/components/parameters/LimitParam'
       responses:
         '200':
           description: An array of Player objects
@@ -139,9 +139,9 @@ paths:
           schema:
             $ref: '#/components/schemas/RunFields'
           description: Column to sort on
-        - $ref: '#/components/parameters/orderParam'
-        - $ref: '#/components/parameters/offsetParam'
-        - $ref: '#/components/parameters/limitParam'
+        - $ref: '#/components/parameters/OrderParam'
+        - $ref: '#/components/parameters/OffsetParam'
+        - $ref: '#/components/parameters/LimitParam'
       responses:
         '200':
           description: An array of Run objects
@@ -212,9 +212,9 @@ paths:
           schema:
             $ref: '#/components/schemas/ServerFields'
           description: Column to sort on
-        - $ref: '#/components/parameters/orderParam'
-        - $ref: '#/components/parameters/offsetParam'
-        - $ref: '#/components/parameters/limitParam'
+        - $ref: '#/components/parameters/OrderParam'
+        - $ref: '#/components/parameters/OffsetParam'
+        - $ref: '#/components/parameters/LimitParam'
       responses:
         '200':
           description: An array of Server objects
@@ -283,7 +283,7 @@ components:
         tier:
           type: integer
           description: Difficulty tier of the map
-        created_at:
+        createdAt:
           type: string
           format: date
           description: When the map was created
@@ -344,10 +344,10 @@ components:
         jumps:
           type: integer
           description: The amount of jumps in the run
-        player_name:
+        playerName:
           type: string
           description: The name of the player that hit the run
-        map_name:
+        mapName:
           type: string
           description: The name of the map the run was on
         style:
@@ -376,17 +376,17 @@ components:
           type: string
           format: ipv4
           description: Server IP address
-        discord_link:
+        discordLink:
           type:
             - 'null'
             - string
           description: A link to the server's discord (if it exists)
-        owner_steamid:
+        ownerSteamid:
           type:
             - 'null'
             - integer
           description: The SteamID64 of the server's owner (if it exists)
-        country_name:
+        countryName:
           type: string
           description: The country the server is hosted in
     ServerArray:
@@ -400,7 +400,7 @@ components:
         - id
         - name
         - tier
-        - created_at
+        - createdAt
         - author
     PlayerFields:
       type: string
@@ -420,8 +420,8 @@ components:
         - sync
         - strafes
         - jumps
-        - player_name
-        - map_name
+        - playerName
+        - mapName
         - style
         - server
         - points
@@ -431,17 +431,17 @@ components:
         - id
         - name
         - address
-        - discord_link
-        - owner_steamid
-        - country_name
+        - discordLink
+        - ownerSteamid
+        - countryName
   parameters:
-    offsetParam:
+    OffsetParam:
       in: query
       name: offset
       schema:
         type: integer
       description: The number of items to offset the result by
-    orderParam:
+    OrderParam:
       in: query
       name: order
       schema:
@@ -453,7 +453,7 @@ components:
         Sort order (by Run ID):
           * `asc` - Ascending, from low to high
           * `desc` - Descending, from high to low
-    limitParam:
+    LimitParam:
       in: query
       name: limit
       schema:

--- a/openapi.yml
+++ b/openapi.yml
@@ -55,6 +55,27 @@ paths:
           description: Unexpected error
   # /maps/{map}/zones:
   # to be fleshed out upon zone discussion
+  /players:
+    get:
+      summary: Return a list of all players
+      tags:
+        - players
+      parameters:
+        - in: query
+          name: sort
+          schema:
+            $ref: '#/components/schemas/PlayerFields'
+          description: Column to sort on
+        - $ref: '#/components/parameters/orderParam'
+        - $ref: '#/components/parameters/offsetParam'
+        - $ref: '#/components/parameters/limitParam'
+      responses:
+        '200':
+          description: An array of Player objects
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PlayerArray'
   /players/{player}:
     get:
       summary: Return detailed information about a player


### PR DESCRIPTION
An initial OpenAPI specification, completely open to be changed at this point in time. Initial endpoints and schemas are based on discussions within the new-api channel on Discord. Unfortunately GitHub doesn't have any built in OpenAPI doc rendering (unlike GitLab) so anyone wanting to contribute to discussion will have to look at rendering it themselves or just reading the raw YAML.